### PR TITLE
Extracted zookeeper role name from recipe to be defined as an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default[:kafka][:log_flush_interval] = 10000
 default[:kafka][:log_flush_time_interval] = 1000
 default[:kafka][:log_flush_scheduler_time_interval] = 1000
 default[:kafka][:log_retention_hours] = 168
+default[:kafka][:zk_role] = "zookeeper"
 default[:kafka][:zk_connectiontimeout] = 10000
 
 default[:kafka][:user] = "kafka"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email  "ivan.vonnagy@webtrends.com"
 license           "Apache 2.0"
 description       "Intalls and configures a Kafka broker"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.0.20"
+version           "1.0.21"
 
 depends           "java"
 depends           "runit"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -134,7 +134,7 @@ end
 # grab the zookeeper nodes that are currently available
 zookeeper_pairs = Array.new
 if not Chef::Config.solo
-  search(:node, "role:zookeeper AND chef_environment:#{node.chef_environment}").each do |n|
+  search(:node, "role:#{node[:kafka][:zk_role]} AND chef_environment:#{node.chef_environment}").each do |n|
     zookeeper_pairs << "#{n[:fqdn]}:#{n[:zookeeper][:client_port]}"
   end
 end


### PR DESCRIPTION
The current recipe hard locks you to a specific role name for the zookeeper cluster. By extracting that role to an attribute you can the ability to change it and have multiple Kafka clusters using the same cookbook just by having several unique zookeeper cluster roles.
